### PR TITLE
Update P1AM to add reference to I2C pins

### DIFF
--- a/modules/P1AM-100/P1AM-100.html
+++ b/modules/P1AM-100/P1AM-100.html
@@ -219,6 +219,18 @@
 						<td style=min-width:50px>0, 1, 4-8, A1, A2</td>	
 					</tr>
 					<tr>
+						<td style=min-width:50px>SPI</td>
+						<td style=min-width:50px>8, 9, 10</td>	
+					</tr>
+					<tr>
+						<td style=min-width:50px>I2C</td>
+						<td style=min-width:50px>11, 12</td>	
+					</tr>
+					<tr>
+						<td style=min-width:50px>UART</td>
+						<td style=min-width:50px>13, 14</td>	
+					</tr>
+					<tr>
 						<td style=min-width:50px>5V</td>
 						<td style=min-width:50px>5V supply output</td>
 					</tr>


### PR DESCRIPTION
Adding in reference to I2C pins, as there is no reference in the documentation that they exist.