### PR TITLE
Fix minor typos

### DIFF
--- a/main.js
+++ b/main.js
@@ -322,7 +322,7 @@ function generateConfigTool(properties, container) {
     } else {
         previewCode.className = "cpp";
         cppButton.classList.add("active");
-        previewCode.innerText = "const char " + currentModule.name.replace(/-/g, "_").toUpperCase() + "_CONFIG[] = { " + generateConfigArray() + " };";
+        previewCode.innerText = "const char " + currentModule.name.replace(/-/g, "_").toUpperCase() + "_config[] = { " + generateConfigArray() + " };";
     }
     previewCode.classList.add("config");
     pre.appendChild(previewCode);

--- a/modules/P1AM-100/P1AM-100.html
+++ b/modules/P1AM-100/P1AM-100.html
@@ -137,7 +137,7 @@
 		
 		<h4>Toggle Switch</h4>
 		 <p> 
-			The toggle switch be can used like a normal digital input. It doesn't alter any behaviour on it's own so make sure to 
+			The toggle switch can be used like a normal digital input. It doesn't alter any behaviour on its own so make sure to
 			write code to include any desired functionality. It can be referenced using 31 or SWITCH_BUILTIN. 
 			Set it as an input using pinMode() and read it using digitalRead(). 
 			<div class="code-block">
@@ -178,7 +178,7 @@
 		</p>
 		<h4>RTC</h4>
 		 <p> 
-			The P1AM-100 contatins an internal RTC (real-time clock) powered by a 32.768 kHz Crystal. An RTC is a clock that keeps track of the current time and can be used to program actions at a certain time.
+			The P1AM-100 contains an internal RTC (real-time clock) powered by a 32.768 kHz Crystal. An RTC is a clock that keeps track of the current time and can be used to program actions at a certain time.
 			To use the RTC feature download the <b>RTCZero</b> library from the Arduino Library Manager and check out their examples.
 			For more in depth information, see their <a href="https://www.arduino.cc/en/Reference/RTC">API reference.</a>
 		</p>

--- a/modules/P1AM-200/P1AM-200.html
+++ b/modules/P1AM-200/P1AM-200.html
@@ -126,14 +126,14 @@
 		
 		<h4>Toggle Switch</h4>
 		 <p> 
-			The toggle switch be can used like a normal digital input. It doesn't alter any behaviour on it's own so make sure to 
+			The toggle switch can be used like a normal digital input. It doesn't alter any behaviour on its own so make sure to
 			write code to include any desired functionality. 
             <div class="change-container">
                 <button class="change-cpp active">Arduino</button>
                 <button class="change-py">Python</button>
             </div> 
 			<div class="code-block">
-                <pre><code class="cpp">pinMode(SWITCH_BUILTIN,INPUT);	//Set Swtich to be a digital input
+                <pre><code class="cpp">pinMode(SWITCH_BUILTIN,INPUT);	//Set Switch to be a digital input
 				Serial.println(digitalRead(SWITCH_BUILTIN));	//Read and print out state of switch. 1 is up and 0 is down.
 				</code></pre>
                 <pre style="display: none;"><code class="py"><pre>from board import SWITCH
@@ -207,7 +207,7 @@ while True:
 		</p>
 		<h4>RTC</h4>
 		 <p> 
-			The P1AM-200 contatins an external  RTC (real-time clock) backed by a supercap. This allows the board to keep track of time even when it is powered off and should function up to 12 hours. 
+			The P1AM-200 contains an external RTC (real-time clock) backed by a supercap. This allows the board to keep track of time even when it is powered off and should function up to 12 hours.
 		</p>
         <h4>microSD Card</h4>
         <p> 

--- a/modules/P1AM-200/P1AM-200.html
+++ b/modules/P1AM-200/P1AM-200.html
@@ -157,7 +157,7 @@ while True:
 
        <div class="code-block">
         <pre><code class="cpp">Adafruit_NeoPixel pixels(1, NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800); // Setup RGB LED
-            pixels.setPixelColor(i, pixels.Color(0, 150, 0)); // Set RGB LED to green (R, G, B)                          
+            pixels.setPixelColor(0, pixels.Color(0, 150, 0)); // Set RGB LED to green (R, G, B)
             pixels.show(); // Update RGB LED
             </code></pre>
         <pre style="display: none;"><code class="py">from p1am_200_helpers import get_neopixel

--- a/modules/P1AM-200/P1AM-200.html
+++ b/modules/P1AM-200/P1AM-200.html
@@ -157,6 +157,7 @@ while True:
 
        <div class="code-block">
         <pre><code class="cpp">Adafruit_NeoPixel pixels(1, NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800); // Setup RGB LED
+            pixels.begin(); // Initialize NeoPixel object
             pixels.setPixelColor(0, pixels.Color(0, 150, 0)); // Set RGB LED to green (R, G, B)
             pixels.show(); // Update RGB LED
             </code></pre>

--- a/modules/P1AM-200/P1AM-200.html
+++ b/modules/P1AM-200/P1AM-200.html
@@ -134,7 +134,7 @@
             </div> 
 			<div class="code-block">
                 <pre><code class="cpp">pinMode(SWITCH_BUILTIN,INPUT);	//Set Swtich to be a digital input
-				Serial.println(digitalRead(SWITCH_BUILTIN);	//Read and print out state of switch. 1 is up and 0 is down.
+				Serial.println(digitalRead(SWITCH_BUILTIN));	//Read and print out state of switch. 1 is up and 0 is down.
 				</code></pre>
                 <pre style="display: none;"><code class="py"><pre>from board import SWITCH
 import digitalio

--- a/modules/P1AM-GPIO/P1AM-GPIO.html
+++ b/modules/P1AM-GPIO/P1AM-GPIO.html
@@ -41,7 +41,7 @@
     </div>
     <div class="content">
         <div class="description">
-            <p>The P1AM-GPIO is an industrial rated shield that provides a convienient connection from most of
+            <p>The P1AM-GPIO is an industrial rated shield that provides a convenient connection from most of
 				the P1AM-100 GPIO pins to the front 18 position terminal block connector. The signal level for 
 				the GPIO pins is 3.3V. All GPIO pins (except for DAC0) include basic electrical protection including: ESD suppression, overvoltage, and overcurrent protection. 
 				The VCC pin includes a PTC resettable fuse(Trip - 420mA; Hold - 200mA) to protect against overloading the 3.3V supply.

--- a/modules/P1AM-SERIAL/P1AM-SERIAL.html
+++ b/modules/P1AM-SERIAL/P1AM-SERIAL.html
@@ -164,7 +164,7 @@
                         port2.write(b"Hello Port 1!\n")</code></pre>
                 </div>
                 
-                <p>RS485 communications use the rs485_wrapper library to automtically control transmit and receive modes.</p>
+                <p>RS485 communications use the rs485_wrapper library to automatically control transmit and receive modes.</p>
                 <div class="code-block">
                     <pre style="display: none;"><code class="py">import board
                         import busio


### PR DESCRIPTION
I found a couple typos when reviewing the docs. One is a missing closing parentheses and the other is the generation of a variable name using capital letters when the example code below it uses the same variable with lowercase letters.